### PR TITLE
limit "First Use in Database" date to after 1000th occurrence

### DIFF
--- a/data-mining/osm-tags-wiki-vs-osmdata/index.js
+++ b/data-mining/osm-tags-wiki-vs-osmdata/index.js
@@ -23,14 +23,17 @@ const miningQueue = queue(3)
 out.data.forEach(wikipage => {
   miningQueue.defer(callback => {
     fetch(`http://taghistory.raifer.tech/***/${encodeURIComponent(wikipage.key)}${(wikipage.value !== '*') ? '/' + encodeURIComponent(wikipage.value) : ''}`)
-      .then(response => response.json())
-      .then(json => {
-        if (json.length == 0 || json[0].date == undefined) callback(null)
-        callback(null, {
-          date: json[0].date.substr(0, 10),
-          count: json[json.length - 1].count,
-        })
-    }).catch(callback)
+    .then(response => response.json())
+    .then(json => {
+      if (json.length == 0 || json[0].date == undefined) callback(null)
+      const threshold = 1000
+      date = json.reduce((acc,val) => (acc === '' && val.count > threshold) ? val.date : acc, '')
+      callback(null, {
+        date: date.substr(0, 10),//json[0].date.substr(0, 10),
+        count: json[json.length - 1].count,
+      })
+    })
+    .catch(callback)
   })
 })
 

--- a/visualizations/osm-tags-wiki-vs-osmdata/script.js
+++ b/visualizations/osm-tags-wiki-vs-osmdata/script.js
@@ -1,46 +1,46 @@
 d3.json('../data/osm-tags-wiki-vs-osmdata.json', dataset => {
-  const data = dataset.data.filter(d => d['date-wiki'] !== null && d['date-data'] !== null)
+  const data = dataset.data.filter(d => d['date-wiki'] !== null && d['date-data'] !== null && d['date-data'] !== '')
   data.forEach(d => {
     d['date-wiki'] = new Date(d['date-wiki'])
     d['date-data'] = new Date(d['date-data'])
     d['count'] = +d['count']
   })
-  
+
   const dates = R.compose(R.map(moment), R.flatten)([R.map(R.prop('date-wiki'), data), R.map(R.prop('date-data'), data)])
   const datesInterval = [moment.min(dates), moment.max(dates)]
-  
+
   const formatDate = d3.timeFormat('%Y-%m-%d')
-  
+
   const width = window.innerWidth
   const height = window.innerHeight
   const svg = pageFixed(width, height, 0, 0)
-  
+
   const x0 = datesInterval
   const y0 = datesInterval
   const x = d3.scaleUtc().domain(x0).range([0, width])
   const y = d3.scaleUtc().domain(y0).range([height, 0])
   const r = d3.scalePow().exponent(.25).domain([0, 1E7]).range([2, 10])
   const key = d3.scaleOrdinal(d3.schemeCategory20)
-  
+
   const xAxis = d3.axisTop(x).ticks(12)
   const yAxis = d3.axisRight(y).ticks(12 * height / width)
   const yAxis2 = d3.axisLeft(y).ticks(12 * height / width)
-  
+
   const brush = d3.brush().on('end', () => brushended())
-  
+
   var idleTimeout
   const idleDelay = 350
-  
+
   // tooltip
   initDataTooltip()
-  
+
   // diagonal
   svg.append('g')
     .append('path')
       .classed('diagonal', true)
       .data([datesInterval])
       .attr('d', d3.line().x(x).y(y))
-  
+
   // brush
   svg.append('g')
     .classed('brush', true)
@@ -74,7 +74,7 @@ d3.json('../data/osm-tags-wiki-vs-osmdata.json', dataset => {
     svg.selectAll('.diagonal').transition(t)
       .attr('d', d3.line().x(x).y(y))
   }
-  
+
   // data
   svg.selectAll('circle')
     .data(data)
@@ -86,7 +86,7 @@ d3.json('../data/osm-tags-wiki-vs-osmdata.json', dataset => {
       .attr('opacity', .75)
       .on('mouseover', d => showDataTooltip(d3.event.pageX, d3.event.pageY, `${d['key']}=${d['value']}`, `<span class="date">${formatDate(d['date-wiki'])}</span> first documention in the OSM wiki<br><span class="date">${formatDate(d['date-data'])}</span> first use in the OSM database`))
       .on('mouseout', () => hideDataTooltip())
-  
+
   // axes
   const axes = svg.append('g')
     .classed('axes', true)
@@ -114,7 +114,7 @@ d3.json('../data/osm-tags-wiki-vs-osmdata.json', dataset => {
     .attr('y', 50)
     .style('text-anchor', 'middle')
     .text('first use in OSM database')
-  
+
   // page
   initPage({
     infoDescription: 'The core tags, which are used in OSM to describe nodes, ways, and relations, are usually documented in the <a href="https://wiki.openstreetmap.org/wiki/Map_Features" target="_blank">OSM wiki</a>. There is, however, no formal requirement to do so, and tags are, in consequence, used in the OSM database often before they are documented in the OSM wiki, if at all. This visualization explores how these two dates, the first use in the OSM database and the first documentation in the OSM wiki, correlate.',


### PR DESCRIPTION
Looks like this:
![selection_027](https://cloud.githubusercontent.com/assets/1927298/26167824/3ddf3e7a-3b38-11e7-8de1-31a7782fb2b0.png)

One issue: not all tags have 1000 occurrences (now they are skipped in the final visualization): maybe fall back to a smaller threshold in such cases? Similarly: for tags that we have only few more than 1000 objects, the date will be quite late on the timeline.